### PR TITLE
Ensure correct Python version is installed in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Python ${{ matrix.python }}
         uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Without this patch if you look at CI, everything is run with the current installed version of python: 3.10.