### PR TITLE
Fix v1.0.3 changelog typo

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ Release 1.0.4 (2023-01-21)
 Release 1.0.3 (2023-01-08)
 ==========================
 
-* Drop Python 3.8 and lower
+* Drop Python 3.7 and lower
 * Fix deprecation warnings from Sphinx 6.1
 
 Release 1.0.2 (2019-02-29)


### PR DESCRIPTION
hi! the changelog entry for v1.0.3 states that it dropped support for Python 3.8, which appears to be a typo:

* 105de76e44b529bacc9252d68bfbe32e79360843 dropped 3.{5,6}.
* b11afda3eb587a8eb18a931892046137f46df717 dropped 3.7.
* v1.0.3 package metadata proclaims 3.8 support.